### PR TITLE
Patch `jsonrpc` crate

### DIFF
--- a/simulators/rpc-compat/Cargo.lock
+++ b/simulators/rpc-compat/Cargo.lock
@@ -366,8 +366,7 @@ dependencies = [
 [[package]]
 name = "jsonrpc"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248ea3eab5d9a37ee324b1f576f19d274ff7e56cd5206ea4755a7ef918e94fa4"
+source = "git+https://github.com/apoelstra/rust-jsonrpc.git?branch=master#1063671f122a8985c1b7c29030071253da515839"
 dependencies = [
  "base64",
  "serde",

--- a/simulators/rpc-compat/Cargo.toml
+++ b/simulators/rpc-compat/Cargo.toml
@@ -22,3 +22,6 @@ serde_json = "1.0.87"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 tokio = { version = "1", features = ["full"] }
+
+[patch.crates-io]
+jsonrpc = { git = "https://github.com/apoelstra/rust-jsonrpc.git", branch = "master" }


### PR DESCRIPTION
Use `jsonrpc` latest master with HTTP `host` header fix.